### PR TITLE
Maxmind requires a licence key for downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ heroku config:add MAXMIND_DB_NAME=City
 heroku config:add MAXMIND_DB_NAME=Country
 ```
 
+Add your licence key, which is now a requirement for downloading even the free databases.
+```
+heroku config:add MAXMIND_KEY=Your-License-key
+```
+
 Then deploy and start using the database.
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then deploy and start using the database.
 
 ## Credits
 
-(c) 2017 physiovia GmbH
+Forked from physiovia GmbH https://github.com/physiovia/heroku-buildpack-maxmind-geolite2
 
 Heavily inspired by https://github.com/mantisadnetwork/heroku-buildpack-maxmind. Check out this buildpack if you're using the paid versions of MaxMind.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then deploy and start using the database.
 
 ## Credits
 
-Forked from physiovia GmbH https://github.com/physiovia/heroku-buildpack-maxmind-geolite2
+(c) 2017 physiovia GmbH
 
 Heavily inspired by https://github.com/mantisadnetwork/heroku-buildpack-maxmind. Check out this buildpack if you're using the paid versions of MaxMind.
 

--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,13 @@ if [ ! -f "$ENV_DIR/MAXMIND_DB_NAME" ]; then
   exit 1
 fi
 
+if [ ! -f "$ENV_DIR/MAXMIND_KEY" ]; then
+  echo "-----> You need to set the environment variable MAXMIND_KEY with your licence key from Maxmind."
+
+  exit 1
+fi
+
+MAXMIND_KEY=`cat $ENV_DIR/MAXMIND_KEY`
 MAXMIND_DB_NAME=`cat $ENV_DIR/MAXMIND_DB_NAME`
 MAXMIND_FULL_DB_NAME="GeoLite2-$MAXMIND_DB_NAME"
 
@@ -43,20 +50,20 @@ if [ ! -f $DB ]; then
   if [ ! -f $ARCHIVE ]; then
     echo "-----> $MAXMIND_FULL_DB_NAME: Database does not exist in cache, downloading."
 
-    url="http://geolite.maxmind.com/download/geoip/database/$MAXMIND_FULL_DB_NAME"
+    url="https://download.maxmind.com/app/geoip_download?edition_id=${MAXMIND_FULL_DB_NAME}&license_key=${MAXMIND_KEY}&suffix=tar.gz"
 
-    curl -o $ARCHIVE -L "$url.mmdb.gz"
+    curl -o $ARCHIVE -L $url
     curl -o $CHECKSUM_FILE -L "$url.md5"
   fi
+
+  echo "-----> $MAXMIND_FULL_DB_NAME: Comparing checksums"
+
+  calculated_checksum=`openssl md5 $ARCHIVE | egrep -o '([a-f0-9]+)$'`
+  expected_checksum=`cat $CHECKSUM_FILE`
 
   echo "-----> $MAXMIND_FULL_DB_NAME: Extracting $ARCHIVE"
 
   gunzip $ARCHIVE
-
-  echo "-----> $MAXMIND_FULL_DB_NAME: Comparing checksums"
-
-  calculated_checksum=`openssl md5 $DB | egrep -o '([a-f0-9]+)$'`
-  expected_checksum=`cat $CHECKSUM_FILE`
 
   if [ $calculated_checksum != $expected_checksum ]; then
     echo "-----> Invalid checksum: expected $expected_checksum, got $calculated_checksum."

--- a/bin/compile
+++ b/bin/compile
@@ -27,7 +27,7 @@ mkdir -p $CACHE_DIR
 
 ARCHIVE="$CACHE_DIR/$MAXMIND_FULL_DB_NAME.mmdb.gz"
 CHECKSUM_FILE="$CACHE_DIR/$MAXMIND_FULL_DB_NAME.md5"
-DB="$CACHE_DIR/$MAXMIND_FULL_DB_NAME.mmdb"
+DB="$CACHE_DIR/${MAXMIND_FULL_DB_NAME}_*/$MAXMIND_FULL_DB_NAME.mmdb"
 LAST="$CACHE_DIR/$MAXMIND_FULL_DB_NAME.last"
 
 if [ -f $DB ]; then
@@ -61,15 +61,15 @@ if [ ! -f $DB ]; then
   calculated_checksum=`openssl md5 $ARCHIVE | egrep -o '([a-f0-9]+)$'`
   expected_checksum=`cat $CHECKSUM_FILE`
 
-  echo "-----> $MAXMIND_FULL_DB_NAME: Extracting $ARCHIVE"
-
-  gunzip $ARCHIVE
-
   if [ $calculated_checksum != $expected_checksum ]; then
     echo "-----> Invalid checksum: expected $expected_checksum, got $calculated_checksum."
 
     exit 1
   fi
+
+  echo "-----> $MAXMIND_FULL_DB_NAME: Extracting $ARCHIVE"
+
+  gunzip -c $ARCHIVE | tar -x -C $CACHE_DIR -f -
 
   touch $LAST
 else


### PR DESCRIPTION
https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/

On December 30, 2019, downloads will no longer be served from our public GeoLite2 page, from geolite.maxmind.com/download/geoip/database/*, or from any other public URL.

This change allows you to configure the buildpack with your free license key from the Maxmind site and download the geolite2 database from the new secured URLs.